### PR TITLE
Use Noto Sans and Adobe Kaiti Regular as alternative fonts

### DIFF
--- a/.github/workflows/xelatex.yml
+++ b/.github/workflows/xelatex.yml
@@ -21,7 +21,14 @@ jobs:
         uses: xu-cheng/latex-action@v2
         with:
           extra_system_packages: "font-noto font-noto-cjk font-noto-cjk-extra"
-          pre_compile: "pushd /usr/share/fonts; mkdir kaiti; cd kaiti; wget https://github.com/dolbydu/font/raw/master/unicode/STKaiti.TTF; popd"
+          pre_compile: > 
+            pushd /usr/share/fonts; 
+            mkdir kaiti; 
+            cd kaiti; 
+            wget https://github.com/dolbydu/font/raw/master/unicode/STKaiti.TTF; 
+            wget https://github.com/dolbydu/font/raw/master/unicode/Kaiti.ttf;
+            wget https://github.com/dolbydu/font/raw/master/unicode/Adobe%20Kaiti%20Std.otf; 
+            popd
           root_file: 100-most-common-radicals.tex
           latexmk_use_xelatex: true
           latexmk_shell_escape: true

--- a/.github/workflows/xelatex.yml
+++ b/.github/workflows/xelatex.yml
@@ -5,11 +5,13 @@ on:
       - main
     paths: 
       - '**.tex'
+      - '**.inc'
   pull_request:
     branches:
       - main
     paths: 
       - '**.tex'  
+      - '**.inc'
   workflow_dispatch:
 jobs:
   build_latex:

--- a/.github/workflows/xelatex.yml
+++ b/.github/workflows/xelatex.yml
@@ -21,6 +21,7 @@ jobs:
         uses: xu-cheng/latex-action@v2
         with:
           extra_system_packages: "font-noto font-noto-cjk font-noto-cjk-extra"
+		  pre_compile: "pushd /usr/share/fonts; mkdir kaiti; cd kaiti; wget https://github.com/dolbydu/font/raw/master/unicode/STKaiti.TTF; popd"
           root_file: 100-most-common-radicals.tex
           latexmk_use_xelatex: true
           latexmk_shell_escape: true

--- a/.github/workflows/xelatex.yml
+++ b/.github/workflows/xelatex.yml
@@ -21,7 +21,7 @@ jobs:
         uses: xu-cheng/latex-action@v2
         with:
           extra_system_packages: "font-noto font-noto-cjk font-noto-cjk-extra"
-		  pre_compile: "pushd /usr/share/fonts; mkdir kaiti; cd kaiti; wget https://github.com/dolbydu/font/raw/master/unicode/STKaiti.TTF; popd"
+          pre_compile: "pushd /usr/share/fonts; mkdir kaiti; cd kaiti; wget https://github.com/dolbydu/font/raw/master/unicode/STKaiti.TTF; popd"
           root_file: 100-most-common-radicals.tex
           latexmk_use_xelatex: true
           latexmk_shell_escape: true

--- a/100-most-common-radicals.inc
+++ b/100-most-common-radicals.inc
@@ -97,4 +97,4 @@
 \clnk{卩}&\clnk{卩}&&seal&\lnk{jie2}{(jie2)}&\clnk{卷}\clnk{印}\clnk{却}\clnk{即}\clnk{危}&&单耳刀\nl
 \clnk{罒}&\clnk{罒}&\clnk{网}&net&\lnk{wang3}{wang3}&\clnk{罗}\clnk{罚}\clnk{罢}\clnk{罪}\clnk{罩}&Note that the horizontal version can also mean {\em net}.&四字头（罒）\nl
 \clnk{士}&\clnk{士}&&scholar&\lnk{shi4}{shi4}&\clnk{吉}\clnk{壶}\clnk{志}\clnk{声}\clnk{壮}&Note similarity to \clnk{土}, which means {\em earth}.&士字旁\nl
-\clnk{勹}&\clnk{勹}&&embrace, wrap&\lnk{bao1}{(bao1)}&\clnk{包}\clnk{勿}\clnk{勾}\clnk{勺}\clnk{勻}&&包字头\nl
+\clnk{勹}&\clnk{勹}&&embrace, wrap&\lnk{bao1}{(bao1)}&\clnk{包}\clnk{勿}\clnk{勾}\clnk{勺}\clnk{勻}&&包字头

--- a/100-most-common-radicals.tex
+++ b/100-most-common-radicals.tex
@@ -18,8 +18,8 @@
 \usepackage{catchfile}
 \usepackage{collcell}
 
-\setmainfont{Noto Sans}
-\setsansfont{Noto Sans}
+\setmainfont[Scale=0.9]{Noto Sans}
+\setsansfont[Scale=0.9]{Noto Sans}
 \setCJKmainfont{Adobe Kaiti Std}
 
 \newcommand{\nl}{\\}

--- a/100-most-common-radicals.tex
+++ b/100-most-common-radicals.tex
@@ -18,9 +18,9 @@
 \usepackage{catchfile}
 \usepackage{collcell}
 
-\setmainfont{Noto Sans CJK SC}
-\setsansfont{Noto Sans CJK SC}
-\setCJKmainfont{STKaiti}
+\setmainfont{Noto Sans}
+\setsansfont{Noto Sans}
+\setCJKmainfont{Adobe Kaiti Std}
 
 \newcommand{\nl}{\\}
 

--- a/100-most-common-radicals.tex
+++ b/100-most-common-radicals.tex
@@ -20,7 +20,7 @@
 
 \setmainfont{Noto Sans CJK SC}
 \setsansfont{Noto Sans CJK SC}
-\setCJKmainfont[BoldFont={Noto Sans CJK SC Bold}]{Noto Sans CJK SC}
+\setCJKmainfont{STKaiti}
 
 \newcommand{\nl}{\\}
 

--- a/100-most-common-radicals.tex
+++ b/100-most-common-radicals.tex
@@ -18,8 +18,8 @@
 \usepackage{catchfile}
 \usepackage{collcell}
 
-\setmainfont{Myriad Pro}
-\setsansfont{Myriad Pro}
+\setmainfont{Noto Sans CJK SC}
+\setsansfont{Noto Sans CJK SC}
 \setCJKmainfont[BoldFont={Kaiti SC Bold}]{Kaiti SC}
 
 \newcommand{\nl}{\\}

--- a/100-most-common-radicals.tex
+++ b/100-most-common-radicals.tex
@@ -20,7 +20,7 @@
 
 \setmainfont{Noto Sans CJK SC}
 \setsansfont{Noto Sans CJK SC}
-\setCJKmainfont[BoldFont={Kaiti SC Bold}]{Kaiti SC}
+\setCJKmainfont[BoldFont={Noto Sans CJK SC Bold}]{Noto Sans CJK SC}
 
 \newcommand{\nl}{\\}
 


### PR DESCRIPTION
We should use easily available fonts in the TeX document,
so that others can recompile/retypeset the PDF without 
a hassle. 

* Noto Sans is a good open/free alternative to
  the commercial Myriad Pro font
* as CJK font I retrieve the original Adobe Kaiti
  font, which seems to be the only available variant
  of Kaiti containing all extension characters we need
  to be able to show radical variants
* extend the GH actions workflow accordingly:
  we need to install the Noto font and retrieve
  the additional fonts

Closes #1 